### PR TITLE
Add solution for Maximal Network Rank problem

### DIFF
--- a/Golang problems/Medium/1615_Maximal Network Rank.go
+++ b/Golang problems/Medium/1615_Maximal Network Rank.go
@@ -1,0 +1,77 @@
+/*
+
+There is an infrastructure of n cities with some number of roads connecting these cities. Each roads[i] = [ai, bi] indicates that there is a bidirectional road between cities ai and bi.
+
+The network rank of two different cities is defined as the total number of directly connected roads to either city. If a road is directly connected to both cities, it is only counted once.
+
+The maximal network rank of the infrastructure is the maximum network rank of all pairs of different cities.
+
+Given the integer n and the array roads, return the maximal network rank of the entire infrastructure.
+
+
+
+Example 1:
+
+
+
+Input: n = 4, roads = [[0,1],[0,3],[1,2],[1,3]]
+Output: 4
+Explanation: The network rank of cities 0 and 1 is 4 as there are 4 roads that are connected to either 0 or 1. The road between 0 and 1 is only counted once.
+Example 2:
+
+
+
+Input: n = 5, roads = [[0,1],[0,3],[1,2],[1,3],[2,3],[2,4]]
+Output: 5
+Explanation: There are 5 roads that are connected to cities 1 or 2.
+Example 3:
+
+Input: n = 8, roads = [[0,1],[1,2],[2,3],[2,4],[5,6],[5,7]]
+Output: 5
+Explanation: The network rank of 2 and 5 is 5. Notice that all the cities do not have to be connected.
+
+
+Constraints:
+
+2 <= n <= 100
+0 <= roads.length <= n * (n - 1) / 2
+roads[i].length == 2
+0 <= ai, bi <= n-1
+ai != bi
+
+*/
+
+package main
+
+func maximalNetworkRank(n int, roads [][]int) (ans int) {
+	g := make([][]int, n)
+	cnt := make([]int, n)
+	for i := range g {
+		g[i] = make([]int, n)
+	}
+	for _, r := range roads {
+		a, b := r[0], r[1]
+		g[a][b], g[b][a] = 1, 1
+		cnt[a]++
+		cnt[b]++
+	}
+	for a := 0; a < n; a++ {
+		for b := a + 1; b < n; b++ {
+			ans = max(ans, cnt[a]+cnt[b]-g[a][b])
+		}
+	}
+	return
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	maximalNetworkRank(4, [][]int{{0, 1}, {0, 3}, {1, 2}, {1, 3}})
+	maximalNetworkRank(5, [][]int{{0, 1}, {0, 3}, {1, 2}, {1, 3}, {2, 3}, {2, 4}})
+	maximalNetworkRank(8, [][]int{{0, 1}, {1, 2}, {2, 3}, {2, 4}, {5, 6}, {5, 7}})
+}


### PR DESCRIPTION
Added a new Golang implementation for the problem 1615, Maximal Network Rank. The solution defines two array-like structures to hold the network connectivity and the count of roads for each city, and uses nested loops to calculate maximal network rank, optimizing the selection process. It provides a detailed solutions for the scenario of calculating the highest total number of directly connected roads to a pair of cities in a given network.