### PR TITLE
Add solution for splitting linked list into parts

### DIFF
--- a/Golang problems/Medium/725_Split Linked List in Parts.go
+++ b/Golang problems/Medium/725_Split Linked List in Parts.go
@@ -1,0 +1,74 @@
+/*
+
+Given the head of a singly linked list and an integer k, split the linked list into k consecutive linked list parts.
+
+The length of each part should be as equal as possible: no two parts should have a size differing by more than one. This may lead to some parts being null.
+
+The parts should be in the order of occurrence in the input list, and parts occurring earlier should always have a size greater than or equal to parts occurring later.
+
+Return an array of the k parts.
+
+
+
+Example 1:
+
+
+Input: head = [1,2,3], k = 5
+Output: [[1],[2],[3],[],[]]
+Explanation:
+The first element output[0] has output[0].val = 1, output[0].next = null.
+The last element output[4] is null, but its string representation as a ListNode is [].
+Example 2:
+
+
+Input: head = [1,2,3,4,5,6,7,8,9,10], k = 3
+Output: [[1,2,3,4],[5,6,7],[8,9,10]]
+Explanation:
+The input has been split into consecutive parts with size difference at most 1, and earlier parts are a larger size than the later parts.
+
+
+Constraints:
+
+The number of nodes in the list is in the range [0, 1000].
+0 <= Node.val <= 1000
+1 <= k <= 50
+
+*/
+
+package main
+
+import "fmt"
+
+// Definition for singly-linked list.
+type ListNode struct {
+	Val  int
+	Next *ListNode
+}
+
+func splitListToParts(head *ListNode, k int) []*ListNode {
+	var n int
+	for p := head; p != nil; p = p.Next {
+		n++
+	}
+	width, rem := n/k, n%k
+	ans := make([]*ListNode, k)
+	for i, curr := 0, head; i < k && curr != nil; i++ {
+		ans[i] = curr
+		size := width
+		if i < rem {
+			size++
+		}
+		for j := 1; j < size; j++ {
+			curr = curr.Next
+		}
+		curr, curr.Next = curr.Next, nil
+	}
+	return ans
+}
+
+func main() {
+	head := &ListNode{Val: 1, Next: &ListNode{Val: 2, Next: &ListNode{Val: 3}}}
+	k := 5
+	fmt.Println(splitListToParts(head, k))
+
+}


### PR DESCRIPTION
Implemented the function `splitListToParts` in Golang to solve the problem of splitting a singly linked list into k parts as equally as possible. This solution is part of the Medium level problems in Golang. Exploring the linked list to calculate the overall length, the function subsequently calculates the width and remainder. It then iteratively splits the linked list into the desired parts and assigns them into an array. The parts are in order of occurrence in the original linked list.