### PR TITLE
Add solution for Min Cost to Connect All Points problem

### DIFF
--- a/Python problems/Medium/1584_Min Cost to Connect All Points.py
+++ b/Python problems/Medium/1584_Min Cost to Connect All Points.py
@@ -1,0 +1,63 @@
+# You are given an array points representing integer coordinates of some points on a 2D-plane, where points[i] = [xi, yi].
+#
+# The cost of connecting two points [xi, yi] and [xj, yj] is the manhattan distance between them: |xi - xj| + |yi - yj|, where |val| denotes the absolute value of val.
+#
+# Return the minimum cost to make all points connected. All points are connected if there is exactly one simple path between any two points.
+#
+#
+#
+# Example 1:
+#
+#
+# Input: points = [[0,0],[2,2],[3,10],[5,2],[7,0]]
+# Output: 20
+# Explanation:
+#
+# We can connect the points as shown above to get the minimum cost of 20.
+# Notice that there is a unique path between every pair of points.
+# Example 2:
+#
+# Input: points = [[3,12],[-2,5],[-4,1]]
+# Output: 18
+#
+#
+# Constraints:
+#
+# 1 <= points.length <= 1000
+# -106 <= xi, yi <= 106
+# All pairs (xi, yi) are distinct.
+
+from typing import List
+
+
+class Solution:
+    def minCostConnectPoints(self, points: List[List[int]]) -> int:
+        n = len(points)
+        g = [[0] * n for _ in range(n)]
+        dist = [inf] * n
+        vis = [False] * n
+        for i, (x1, y1) in enumerate(points):
+            for j in range(i + 1, n):
+                x2, y2 = points[j]
+                t = abs(x1 - x2) + abs(y1 - y2)
+                g[i][j] = g[j][i] = t
+        dist[0] = 0
+        ans = 0
+        for _ in range(n):
+            i = -1
+            for j in range(n):
+                if not vis[j] and (i == -1 or dist[j] < dist[i]):
+                    i = j
+            vis[i] = True
+            ans += dist[i]
+            for j in range(n):
+                if not vis[j]:
+                    dist[j] = min(dist[j], g[i][j])
+        return ans
+
+
+if __name__ == '__main__':
+
+    s = Solution()
+    print(s.minCostConnectPoints([[0, 0], [2, 2], [3, 10], [5, 2], [7, 0]]))
+    print(s.minCostConnectPoints([[3, 12], [-2, 5], [-4, 1]]))


### PR DESCRIPTION
This commit adds a new solution to the medium python problem - "1584_Min Cost to Connect All Points". The solution uses a graph representation to find the minimum cost of connecting all points on a 2D plane using the concept of Manhattan distance. The problem description, constraints, and examples are also included in the comments for clarification.