### PR TITLE
3312_Sorted GCD Pair Queries

### DIFF
--- a/Golang problems/Hard/3312_Sorted GCD Pair Queries.go
+++ b/Golang problems/Hard/3312_Sorted GCD Pair Queries.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"slices"
+	"sort"
+)
+
+func gcdValues(nums []int, queries []int64) (ans []int) {
+	mx := slices.Max(nums)
+	cnt := make([]int, mx+1)
+	cntG := make([]int, mx+1)
+	for _, x := range nums {
+		cnt[x]++
+	}
+
+	for i := mx; i > 0; i-- {
+		var v int
+		for j := i; j <= mx; j += i {
+			v += cnt[j]
+			cntG[i] -= cntG[j]
+		}
+		cntG[i] += v * (v - 1) / 2
+	}
+
+	for i := 2; i <= mx; i++ {
+		cntG[i] += cntG[i-1]
+	}
+	for _, q := range queries {
+		ans = append(ans, sort.SearchInts(cntG, int(q)+1))
+	}
+	return
+}

--- a/Golang problems/Hard/3312_Sorted GCD Pair Queries_test.go
+++ b/Golang problems/Hard/3312_Sorted GCD Pair Queries_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGCDValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		nums    []int
+		queries []int64
+		want    []int
+	}{
+		{
+			name:    "mixed gcd values",
+			nums:    []int{2, 3, 4},
+			queries: []int64{0, 1, 2},
+			want:    []int{1, 1, 2},
+		},
+		{
+			name:    "duplicate values",
+			nums:    []int{4, 4, 2, 1},
+			queries: []int64{0, 1, 5},
+			want:    []int{1, 1, 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gcdValues(tt.nums, tt.queries); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("gcdValues(%v, %v) = %v, want %v", tt.nums, tt.queries, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds Go solution and focused tests for LeetCode problem 3312, Hard.

## Summary by Sourcery

Add a Go implementation and tests for solving the LeetCode Hard problem 3312: Sorted GCD Pair Queries.

New Features:
- Introduce gcdValues function that answers sorted GCD pair queries over an integer array.

Tests:
- Add focused unit tests validating gcdValues across mixed and duplicate input scenarios.